### PR TITLE
Better handle when Benchmark is not set

### DIFF
--- a/lib/central_logger/mongo_logger.rb
+++ b/lib/central_logger/mongo_logger.rb
@@ -52,8 +52,6 @@ module CentralLogger
         :request_time => Time.now.getutc,
         :application_name => @application_name
       })
-      # In case of exception, make sure it's set
-      runtime = 0
       runtime = Benchmark.measure do
         yield
       end
@@ -62,6 +60,7 @@ module CentralLogger
       # Reraise the exception for anyone else who cares
       raise e
     ensure
+      runtime ||= Benchmark.measure {}
       insert_log_record(runtime)
     end
 


### PR DESCRIPTION
I haven't done too much testing of this, but I was having a problem where Devise (a Rails gem) was causing central_logger to fail when doing redirects (e.g. forcing a user to log in). I was getting an undefined method error because it was trying to call "0.real" -- so, I just made this create the correct kind of object in the case of failure. I'm not sure if this is the right solution, but I think something needs fixing, and this is my attempt. Thanks!
