### PR TITLE
Bug fix: filter tempfiles from params to avoid BSON::InvalidDocument errors

### DIFF
--- a/lib/central_logger/mongo_logger.rb
+++ b/lib/central_logger/mongo_logger.rb
@@ -126,8 +126,20 @@ module CentralLogger
       end
 
       def insert_log_record(runtime)
+        @mongo_record[:params] = filter_tempfiles(@mongo_record[:params])
         @mongo_record[:runtime] = (runtime * 1000).ceil
         @mongo_connection[@mongo_collection_name].insert(@mongo_record) rescue nil
+      end
+
+      def filter_tempfiles(params)
+        params.inject({}) do |acc, (k, v)|
+          acc[k] = if v.is_a?(Hash)
+            filter_tempfiles(v)
+          else
+            v.is_a?(Tempfile) ? '[Tempfile]' : v
+          end
+          acc
+        end
       end
 
       def level_to_sym(level)


### PR DESCRIPTION
This was an important bug fix for my apps at least. 

It avoids an error that I was seeing a lot of: "Cannot serialize an object of class Tempfile into BSON (BSON::InvalidDocument)" by filtering tempfiles from params.

Again, let me know your level of interest, and/or if you'd like any help. 
