### PR TITLE
Feature request: keep rails logs colored

### DIFF
--- a/lib/central_logger/railtie.rb
+++ b/lib/central_logger/railtie.rb
@@ -6,7 +6,7 @@ if Rails::VERSION::MAJOR == 3
 
     # load earlier than bootstrap.rb initializer loads the default logger.  bootstrap
     # initializer will then skip its own initialization once Rails.logger is defined
-    initializer :initialize_central_logger, :before => :initialize_logger do
+    initializer :initialize_central_logger, :after => :initialize_logger do
       app_config = Rails.application.config
       Rails.logger = config.logger = create_logger(app_config,
                                                    app_config.paths.log.to_a.first)


### PR DESCRIPTION
This commit changes the railtie to initialize central_logger after rails logger to keep the rails logs colored. I'm not sure if this is the right solution, but it seems to help. 
