### PR TITLE
Make compatible with Heroku by adding logs to both Mongo and STDOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Log to a central MongoDB from Rails apps.
 1. For use with Heroku you need to prevent the rails_log_stdout plugin from being added by Heroku:
 
         mkdir vendor/plugins/rails_log_stdout
-	touch vendor/plugins/rails_log_stdout/.gitkeep
+        touch vendor/plugins/rails_log_stdout/.gitkeep
 
 1. If using Rails 3, SKIP this step.  Otherwise, add the following to config/environment.rb:
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Log to a central MongoDB from Rails apps.
 
         include CentralLogger::Filter
 
+1. For use with Heroku you need to prevent the rails_log_stdout plugin from being added by Heroku:
+
+        mkdir vendor/plugins/rails_log_stdout
+	touch vendor/plugins/rails_log_stdout/.gitkeep
+
 1. If using Rails 3, SKIP this step.  Otherwise, add the following to config/environment.rb:
 
        require 'central_logger'

--- a/lib/central_logger/mongo_logger.rb
+++ b/lib/central_logger/mongo_logger.rb
@@ -134,7 +134,8 @@ module CentralLogger
       def connect
         @mongo_connection ||= Mongo::Connection.new(@db_configuration['host'],
                                                     @db_configuration['port'],
-                                                    :auto_reconnect => true).db(@db_configuration['database'])
+                                                    :auto_reconnect => true,
+                                                    :timeout => 5).db(@db_configuration['database'])
 
         if @db_configuration['username'] && @db_configuration['password']
           # the driver stores credentials in case reconnection is required

--- a/lib/central_logger/mongo_logger.rb
+++ b/lib/central_logger/mongo_logger.rb
@@ -37,6 +37,7 @@ module CentralLogger
     end
 
     def add(severity, message = nil, progname = nil, &block)
+      $stdout.puts message
       if @level <= severity && message.present? && @mongo_record.present?
         # do not modify the original message used by the buffered logger
         msg = logging_colorized? ? message.gsub(/(\e(\[([\d;]*[mz]?))?)?/, '').strip : message


### PR DESCRIPTION
Heroku logs require messages to be sent to STDOUT. This patch makes central_logger store logs both in mongodb and output to STDOUT.
