### PR TITLE
Make logging to the rails log file optional

### DIFF
--- a/lib/central_logger/mongo_logger.rb
+++ b/lib/central_logger/mongo_logger.rb
@@ -19,8 +19,12 @@ module CentralLogger
     def initialize(options={})
       path = options[:path] || File.join(Rails.root, "log/#{Rails.env}.log")
       level = options[:level] || DEBUG
-      super(path, level)
       internal_initialize
+      if disable_file_logging?
+        @level = level
+      else
+        super(path, level)
+      end
     rescue => e
       # should use a config block for this
       Rails.env.production? ? (raise e) : (puts "Using BufferedLogger due to exception: " + e.message)
@@ -43,7 +47,7 @@ module CentralLogger
         @mongo_record[:messages][LOG_LEVEL_SYM[severity]] << msg
       end
       # may modify the original message
-      super
+      disable_file_logging? ? message : super
     end
 
     # Drop the capped_collection and recreate it
@@ -86,6 +90,10 @@ module CentralLogger
         configure
         connect
         check_for_collection
+      end
+
+      def disable_file_logging?
+        @db_configuration.fetch('disable_file_logging', false)
       end
 
       def configure

--- a/lib/central_logger/mongo_logger.rb
+++ b/lib/central_logger/mongo_logger.rb
@@ -22,6 +22,9 @@ module CentralLogger
       internal_initialize
       if disable_file_logging?
         @level = level
+        @buffer        = {}
+        @auto_flushing = 1
+        @guard = Mutex.new
       else
         super(path, level)
       end

--- a/test/config/samples/database_no_file_logging.yml
+++ b/test/config/samples/database_no_file_logging.yml
@@ -1,0 +1,9 @@
+test:
+  adapter: mysql
+  username: user
+  database: database
+  mongo:
+    database: system_log
+    application_name: central_foo
+    safe_insert: true
+    disable_file_logging: true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,7 @@ class Test::Unit::TestCase
   CONFIG_DIR = Rails.root.join("config")
   SAMPLE_CONFIG_DIR = File.join(CONFIG_DIR, "samples")
   DEFAULT_CONFIG = "database.yml"
+  DEFAULT_CONFIG_WITH_NO_FILE_LOGGING = "database_no_file_logging.yml"
   DEFAULT_CONFIG_WITH_AUTH = "database_with_auth.yml"
   MONGOID_CONFIG = "mongoid.yml"
   REPLICA_SET_CONFIG = "database_replica_set.yml"

--- a/test/unit/central_logger_test.rb
+++ b/test/unit/central_logger_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 require 'central_logger/mongo_logger'
 require 'tempfile'
+require 'pathname'
 
 # test the basic stuff
 class CentralLogger::MongoLoggerTest < Test::Unit::TestCase
@@ -17,6 +18,7 @@ class CentralLogger::MongoLoggerTest < Test::Unit::TestCase
     context "in instantiation" do
       setup do
         CentralLogger::MongoLogger.any_instance.stubs(:internal_initialize).returns(nil)
+        CentralLogger::MongoLogger.any_instance.stubs(:disable_file_logging?).returns(false)
         @central_logger = CentralLogger::MongoLogger.new
       end
 
@@ -194,6 +196,46 @@ class CentralLogger::MongoLoggerTest < Test::Unit::TestCase
     teardown do
       file = File.join(CONFIG_DIR, DEFAULT_CONFIG)
       File.delete(file) if File.exist?(file)
+    end
+  end
+
+  context "A CentralLogger::MongoLogger without file logging" do
+    setup do
+      FileUtils.cp(File.join(SAMPLE_CONFIG_DIR, DEFAULT_CONFIG_WITH_NO_FILE_LOGGING),  File.join(CONFIG_DIR, DEFAULT_CONFIG))
+      @log_file = Pathname.new('log.out')
+      FileUtils.touch(@log_file)
+    end
+
+    context "in instantiation" do
+      should "not call super in the initialize method" do
+        CentralLogger::MongoLogger.any_instance.expects(:open).never # Stubbing out super doesn't work, so we use this side effect instead.
+        CentralLogger::MongoLogger.new
+      end
+
+      should "set level" do
+        level = stub('level')
+        logger = CentralLogger::MongoLogger.new(:level => level)
+        assert_equal level, logger.level
+      end
+    end
+
+    context "after instantiation" do
+      context "upon insertion of a log record" do
+        setup do
+          @central_logger = CentralLogger::MongoLogger.new(:path => @log_file)
+          log("Test")
+        end
+
+        should "not log the record to a file" do
+          assert_equal '', open(@log_file).read
+        end
+      end
+    end
+
+    teardown do
+      file = File.join(CONFIG_DIR, DEFAULT_CONFIG)
+      File.delete(file) if File.exist?(file)
+      File.delete(@log_file)
     end
   end
 end

--- a/test/unit/central_logger_test.rb
+++ b/test/unit/central_logger_test.rb
@@ -217,6 +217,15 @@ class CentralLogger::MongoLoggerTest < Test::Unit::TestCase
         logger = CentralLogger::MongoLogger.new(:level => level)
         assert_equal level, logger.level
       end
+      should "set buffer" do
+        assert_equal({}, CentralLogger::MongoLogger.new.instance_variable_get(:@buffer))
+      end
+      should "set auto flushing" do
+        assert_equal 1, CentralLogger::MongoLogger.new.instance_variable_get(:@auto_flushing)
+      end
+      should "set guard" do
+        assert CentralLogger::MongoLogger.new.instance_variable_get(:@guard).is_a?(Mutex)
+      end
     end
 
     context "after instantiation" do


### PR DESCRIPTION
Added the ability to turn off logging to the rails log file.

All you need to do is add the following into the yaml config:

```
disable_file_logging: true
```
