### PR TITLE
deprecation warning on start

### DIFF
--- a/lib/central_logger/railtie.rb
+++ b/lib/central_logger/railtie.rb
@@ -9,7 +9,7 @@ if Rails::VERSION::MAJOR == 3
     initializer :initialize_central_logger, :before => :initialize_logger do
       app_config = Rails.application.config
       Rails.logger = config.logger = create_logger(app_config,
-                                                   app_config.paths.log.to_a.first)
+        ((app_config.paths['log'] rescue nil) || app_config.paths.log.to_a).first)
     end
   end
 end


### PR DESCRIPTION
fix «config.paths.app.controller API is deprecated» warning
