### PR TITLE
capsize is passed to the driver as an integer

### DIFF
--- a/lib/central_logger/mongo_logger.rb
+++ b/lib/central_logger/mongo_logger.rb
@@ -155,7 +155,7 @@ module CentralLogger
 
       def create_collection
         @mongo_connection.create_collection(@mongo_collection_name,
-                                            {:capped => true, :size => @db_configuration['capsize']})
+                                            {:capped => true, :size => @db_configuration['capsize'].to_i})
       end
 
       def check_for_collection


### PR DESCRIPTION
When specifying a `capsize` in a `.yml` file, it comes across as a String.

When we upgraded to Mongo 2.0, we started seeing this error:

```
Using BufferedLogger due to exception: Database command 'create' failed: (errmsg: 'exception: specify size:<n> when capped is true'; code: '14832'; ok: '0.0').
```

Casting to an integer fixed the error.
