### PR TITLE
Don't Check in .RVMRC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage
 rdoc
 pkg
 .bundle
+.rvmrc
 cscope.files
 cscope.out
 tags

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm 1.9.2@central_logger


### PR DESCRIPTION
.rvmrc is a per machine configuration and shouldn't be checked into git. This commit removes the file from the repo and adds it to the .gitignore

Note once you pull this in, it will destroy your .rvmrc file locally. Simply re-create it by running this

``` shell
echo rvm 1.9.2@central_logger >> .rvmrc
```
