### PR TITLE
fix for rails 3.2.6 (log level)

### DIFF
--- a/lib/central_logger/mongo_logger.rb
+++ b/lib/central_logger/mongo_logger.rb
@@ -43,7 +43,7 @@ module CentralLogger
     end
 
     def add(severity, message = nil, progname = nil, &block)
-      if @level <= severity && message.present? && @mongo_record.present?
+      if level <= severity && message.present? && @mongo_record.present?
         # do not modify the original message used by the buffered logger
         msg = logging_colorized? ? message.to_s.gsub(/(\e(\[([\d;]*[mz]?))?)?/, '').strip : message
         @mongo_record[:messages][LOG_LEVEL_SYM[severity]] << msg


### PR DESCRIPTION
Hi,
Current version of central_logger does not work with the newest rails (3.2.6).
The fix is very simple, but I'm not sure whether it still works with older rails releases.
Cheers!
